### PR TITLE
nachiguroにcontent sizeのtokens追加

### DIFF
--- a/tokens/nachiguro/size/content.yaml
+++ b/tokens/nachiguro/size/content.yaml
@@ -1,20 +1,32 @@
 size:
   content:
+    xs:
+      value: 544
+      attributes:
+        category: content
+        type: content
+        item: xs
     s:
-      value: 540
+      value: 720
       attributes:
         category: content
         type: content
         item: s
     m:
-      value: 720
+      value: 824
       attributes:
         category: content
         type: content
         item: m
     l:
-      value: 1280
+      value: 1080
       attributes:
         category: content
         type: content
         item: l
+    xl:
+      value: 1280
+      attributes:
+        category: content
+        type: content
+        item: xl


### PR DESCRIPTION
nachiguro-flavoredのcontainerが3種類だけでちょうどいい感じの幅が揃ってなくて導入しにくかったので、他のflavorと同じ5種類に拡張しました。

- xs: 544（最小, ほぼ今のs互換）
- s: 720（シングルペイン・記事コンテンツ向け, 今のm互換）
- m: 824（シングルペイン向け）
- l: 1080（マルチペイン向け, サイドペインが300くらいでメインエリアが700とか）
- xl: 1280（最大, 今のl互換）