### PR TITLE
gapのtokenを更新します

### DIFF
--- a/tokens/apollo/size/gap.yaml
+++ b/tokens/apollo/size/gap.yaml
@@ -43,3 +43,17 @@ size:
           type: gap
           item: base
           subitem: xl
+      xxl:
+        value: '{size.scale.48.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxl
+      xxxl:
+        value: '{size.scale.64.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxxl

--- a/tokens/apollo/size/gap.yaml
+++ b/tokens/apollo/size/gap.yaml
@@ -2,42 +2,42 @@ size:
   gap:
     base:
       xxs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xxs
       xs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xs
       s:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: s
       m:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: m
       l:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: l
       xl:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap

--- a/tokens/flippers/size/gap.yaml
+++ b/tokens/flippers/size/gap.yaml
@@ -43,3 +43,17 @@ size:
           type: gap
           item: base
           subitem: xl
+      xxl:
+        value: '{size.scale.48.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxl
+      xxxl:
+        value: '{size.scale.64.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxxl

--- a/tokens/flippers/size/gap.yaml
+++ b/tokens/flippers/size/gap.yaml
@@ -2,42 +2,42 @@ size:
   gap:
     base:
       xxs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xxs
       xs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xs
       s:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: s
       m:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: m
       l:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: l
       xl:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap

--- a/tokens/kung-pu/size/gap.yaml
+++ b/tokens/kung-pu/size/gap.yaml
@@ -43,3 +43,17 @@ size:
           type: gap
           item: base
           subitem: xl
+      xxl:
+        value: '{size.scale.48.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxl
+      xxxl:
+        value: '{size.scale.64.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxxl

--- a/tokens/kung-pu/size/gap.yaml
+++ b/tokens/kung-pu/size/gap.yaml
@@ -2,42 +2,42 @@ size:
   gap:
     base:
       xxs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xxs
       xs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xs
       s:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: s
       m:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: m
       l:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: l
       xl:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap

--- a/tokens/minne/size/gap.yaml
+++ b/tokens/minne/size/gap.yaml
@@ -43,3 +43,17 @@ size:
           type: gap
           item: base
           subitem: xl
+      xxl:
+        value: '{size.scale.48.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxl
+      xxxl:
+        value: '{size.scale.64.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxxl

--- a/tokens/minne/size/gap.yaml
+++ b/tokens/minne/size/gap.yaml
@@ -2,42 +2,42 @@ size:
   gap:
     base:
       xxs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xxs
       xs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xs
       s:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: s
       m:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: m
       l:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: l
       xl:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap

--- a/tokens/nachiguro/size/gap.yaml
+++ b/tokens/nachiguro/size/gap.yaml
@@ -43,3 +43,17 @@ size:
           type: gap
           item: base
           subitem: xl
+      xxl:
+        value: '{size.scale.48.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxl
+      xxxl:
+        value: '{size.scale.64.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxxl

--- a/tokens/nachiguro/size/gap.yaml
+++ b/tokens/nachiguro/size/gap.yaml
@@ -2,42 +2,42 @@ size:
   gap:
     base:
       xxs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xxs
       xs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xs
       s:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: s
       m:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: m
       l:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: l
       xl:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap

--- a/tokens/pepper/size/gap.yaml
+++ b/tokens/pepper/size/gap.yaml
@@ -43,3 +43,17 @@ size:
           type: gap
           item: base
           subitem: xl
+      xxl:
+        value: '{size.scale.48.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxl
+      xxxl:
+        value: '{size.scale.64.value}'
+        attributes:
+          category: size
+          type: gap
+          item: base
+          subitem: xxxl

--- a/tokens/pepper/size/gap.yaml
+++ b/tokens/pepper/size/gap.yaml
@@ -2,42 +2,42 @@ size:
   gap:
     base:
       xxs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xxs
       xs:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: xs
       s:
-        value: '{size.spacing.base.m.value}'
+        value: '{size.scale.16.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: s
       m:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: m
       l:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap
           item: base
           subitem: l
       xl:
-        value: '{size.spacing.base.l.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: gap


### PR DESCRIPTION
以下の対応をすべてのgap tokenに行いました。
- gapの値を[spacing](https://github.com/pepabo/inhouse-tokens/blob/main/tokens/flippers/size/spacing.yaml)から参照しないようにして、[scale](https://github.com/pepabo/inhouse-tokens/blob/main/tokens/flippers/size/scale.yaml)から参照するように変更しました。
  - 値自体は変更されないようにしています。
- gapのtokenを二段階(xxl, xxxl)分拡張しました。
