### PR TITLE
active stateのtoken追加

### DIFF
--- a/tokens/apollo/color/overlay.yaml
+++ b/tokens/apollo/color/overlay.yaml
@@ -26,12 +26,24 @@ color:
             item: background
             subitem: light
             state: hover
-        focused:
+        active:
           value:
             r: 0
             g: 0
             b: 0
             a: 0.12
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: light
+            state: active
+        focused:
+          value:
+            r: 0
+            g: 0
+            b: 0
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -123,12 +135,24 @@ color:
             item: background
             subitem: dark,
             state: hover
-        focused:
+        active:
           value:
             r: 255
             g: 255
             b: 255
             a: 0.24
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: dark,
+            state: active
+        focused:
+          value:
+            r: 255
+            g: 255
+            b: 255
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -218,12 +242,23 @@ color:
           type: overlay
           item: image
           state: hover
-      focused:
+      active:
         value:
           r: 0
           g: 0
           b: 0
           a: 0.36
+        attributes:
+          category: color
+          type: overlay
+          item: image
+          state: active
+      focused:
+        value:
+          r: 0
+          g: 0
+          b: 0
+          a: 0
         attributes:
           category: color
           type: overlay

--- a/tokens/flippers/color/overlay.yaml
+++ b/tokens/flippers/color/overlay.yaml
@@ -26,12 +26,24 @@ color:
             item: background
             subitem: light
             state: hover
-        focused:
+        active:
           value:
             r: 0
             g: 0
             b: 0
             a: 0.12
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: light
+            state: active
+        focused:
+          value:
+            r: 0
+            g: 0
+            b: 0
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -123,12 +135,24 @@ color:
             item: background
             subitem: dark,
             state: hover
-        focused:
+        active:
           value:
             r: 255
             g: 255
             b: 255
             a: 0.24
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: dark
+            state: active
+        focused:
+          value:
+            r: 255
+            g: 255
+            b: 255
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -218,12 +242,23 @@ color:
           type: overlay
           item: image
           state: hover
-      focused:
+      active:
         value:
           r: 0
           g: 0
           b: 0
           a: 0.36
+        attributes:
+          category: color
+          type: overlay
+          item: image
+          state: active
+      focused:
+        value:
+          r: 0
+          g: 0
+          b: 0
+          a: 0
         attributes:
           category: color
           type: overlay

--- a/tokens/kung-pu/color/overlay.yaml
+++ b/tokens/kung-pu/color/overlay.yaml
@@ -26,12 +26,24 @@ color:
             item: background
             subitem: light
             state: hover
-        focused:
+        active:
           value:
             r: 0
             g: 0
             b: 0
             a: 0.12
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: light
+            state: active
+        focused:
+          value:
+            r: 0
+            g: 0
+            b: 0
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -123,12 +135,24 @@ color:
             item: background
             subitem: dark,
             state: hover
-        focused:
+        active:
           value:
             r: 255
             g: 255
             b: 255
             a: 0.24
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: dark
+            state: active
+        focused:
+          value:
+            r: 255
+            g: 255
+            b: 255
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -218,12 +242,23 @@ color:
           type: overlay
           item: image
           state: hover
-      focused:
+      active:
         value:
           r: 0
           g: 0
           b: 0
           a: 0.36
+        attributes:
+          category: color
+          type: overlay
+          item: image
+          state: active
+      focused:
+        value:
+          r: 0
+          g: 0
+          b: 0
+          a: 0
         attributes:
           category: color
           type: overlay

--- a/tokens/minne/color/overlay.yaml
+++ b/tokens/minne/color/overlay.yaml
@@ -26,12 +26,24 @@ color:
             item: background
             subitem: light
             state: hover
-        focused:
+        active:
           value:
             r: 20
             g: 20
             b: 20
             a: 0.12
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: light
+            state: active
+        focused:
+          value:
+            r: 20
+            g: 20
+            b: 20
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -123,12 +135,24 @@ color:
             item: background
             subitem: dark,
             state: hover
-        focused:
+        active:
           value:
             r: 255
             g: 255
             b: 255
             a: 0.24
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: dark
+            state: active
+        focused:
+          value:
+            r: 255
+            g: 255
+            b: 255
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -218,12 +242,23 @@ color:
           type: overlay
           item: image
           state: hover
-      focused:
+      active:
         value:
           r: 20
           g: 20
           b: 20
           a: 0.36
+        attributes:
+          category: color
+          type: overlay
+          item: image
+          state: active
+      focused:
+        value:
+          r: 20
+          g: 20
+          b: 20
+          a: 0
         attributes:
           category: color
           type: overlay

--- a/tokens/nachiguro/color/overlay.yaml
+++ b/tokens/nachiguro/color/overlay.yaml
@@ -26,12 +26,24 @@ color:
             item: background
             subitem: light
             state: hover
-        focused:
+        active:
           value:
             r: 0
             g: 0
             b: 0
             a: 0.12
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: light
+            state: active
+        focused:
+          value:
+            r: 0
+            g: 0
+            b: 0
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -123,12 +135,24 @@ color:
             item: background
             subitem: dark,
             state: hover
-        focused:
+        active:
           value:
             r: 255
             g: 255
             b: 255
             a: 0.24
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: dark
+            state: active
+        focused:
+          value:
+            r: 255
+            g: 255
+            b: 255
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -218,12 +242,23 @@ color:
           type: overlay
           item: image
           state: hover
-      focused:
+      active:
         value:
           r: 0
           g: 0
           b: 0
           a: 0.36
+        attributes:
+          category: color
+          type: overlay
+          item: image
+          state: active
+      focused:
+        value:
+          r: 0
+          g: 0
+          b: 0
+          a: 0
         attributes:
           category: color
           type: overlay

--- a/tokens/pepper/color/overlay.yaml
+++ b/tokens/pepper/color/overlay.yaml
@@ -26,12 +26,24 @@ color:
             item: background
             subitem: light
             state: hover
-        focused:
+        active:
           value:
             r: 0
             g: 0
             b: 0
             a: 0.12
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: light
+            state: active
+        focused:
+          value:
+            r: 0
+            g: 0
+            b: 0
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -123,12 +135,24 @@ color:
             item: background
             subitem: dark,
             state: hover
-        focused:
+        active:
           value:
             r: 255
             g: 255
             b: 255
             a: 0.24
+          attributes:
+            category: color
+            type: overlay
+            item: background
+            subitem: dark,
+            state: active
+        focused:
+          value:
+            r: 255
+            g: 255
+            b: 255
+            a: 0
           attributes:
             category: color
             type: overlay
@@ -218,12 +242,23 @@ color:
           type: overlay
           item: image
           state: hover
-      focused:
+      active:
         value:
           r: 0
           g: 0
           b: 0
           a: 0.36
+        attributes:
+          category: color
+          type: overlay
+          item: image
+          state: active
+      focused:
+        value:
+          r: 0
+          g: 0
+          b: 0
+          a: 0
         attributes:
           category: color
           type: overlay


### PR DESCRIPTION
- コンポーネントのstateを表現するために[overlayするcolor token](https://design.pepabo.com/inhouse/flavors/color/#overlay-color)に、activeステートのtokenを追加
- focusステートはfocus ringのみで表現する方針のもと、overlayで表面の色が変わらないようなtokenの値に変更

inhouse-components-webのbuttonに反映された様子をキャプチャしました。
![並んだinhouse buttonをキャプチャした映像。左端のボタンにマウスポインターをhoverするとちょっと明るくなって、そのままクリックするとさらに明るくなっている](https://github.com/user-attachments/assets/d09aaf8b-56e4-4e1e-9ca2-2ac1c6350e52)
