### PR TITLE
heightのbaseについてコメントで説明を追加する

### DIFF
--- a/tokens/flippers/size/height.yaml
+++ b/tokens/flippers/size/height.yaml
@@ -1,5 +1,6 @@
 size:
   height:
+    # コンポーネント横断で利用される値をbase以下に記述する
     base:
       interactive-component:
         xs:


### PR DESCRIPTION
heightのbase名前空間以下はinhouse-components-web横断で利用される値を記述するものですが、それがわかりやすいようにコメントをしておきます