### PR TITLE
flippersのテキストカラーを更新します

### DIFF
--- a/tokens/flippers/color/text.yaml
+++ b/tokens/flippers/color/text.yaml
@@ -15,10 +15,10 @@ color:
             subitem: light
         mid_emphasis:
           value:
-            r: 57
-            g: 60
-            b: 65
-            a: 0.6
+            r: 115
+            g: 117
+            b: 120
+            a: 1
           attributes:
             category: color
             type: text
@@ -26,10 +26,10 @@ color:
             subitem: light
         low_emphasis:
           value:
-            r: 57
-            g: 60
-            b: 65
-            a: 0.3
+            r: 196
+            g: 196
+            b: 198
+            a: 1
           attributes:
             category: color
             type: text


### PR DESCRIPTION
mid_emphasis, low_emphasisに関して、アルファ値で強弱を示さないように変更しました。
また、mid_emphasisにおいて、Normal Textが WCAG AAの基準を満たす様に変更しました(背景色が白基準)。