### PR TITLE
flippers の list.leading を 3rem→1.5rem に下げる

### DIFF
--- a/tokens/flippers/size/width.yaml
+++ b/tokens/flippers/size/width.yaml
@@ -123,7 +123,7 @@ size:
           subitem: pict
     list:
       leading:
-        value: '{size.scale.48.value}'
+        value: '{size.scale.40.value}'
         attributes:
           category: size
           type: width

--- a/tokens/flippers/size/width.yaml
+++ b/tokens/flippers/size/width.yaml
@@ -123,7 +123,7 @@ size:
           subitem: pict
     list:
       leading:
-        value: '{size.scale.40.value}'
+        value: '{size.scale.24.value}'
         attributes:
           category: size
           type: width


### PR DESCRIPTION
## 概要

FlippersList の文頭余白（バレット/番号の領域幅）が admin の余白感より広く、置き換え先コンポーネントとして使いにくい問題への対応です。

flippers（カラーミー）の `list.leading` トークンを `{size.scale.48.value}`（3rem / 48px）から **`{size.scale.24.value}`（1.5rem / 24px）** へ下げます。

- 変更は **flippers（カラーミー）のみ**。`tokens/flippers/size/width.yaml` の `list.leading` を変更しています
- `list.leading` は **list 専用トークン**で、他コンポーネントに影響しないため inhouse-tokens 側で対応します
- `description-list.leading`（別トークン `$size-width-description-list-leading`）は **3rem のまま据え置き**

## 変更内容

`tokens/flippers/size/width.yaml`

```diff
     list:
       leading:
-        value: '{size.scale.48.value}'
+        value: '{size.scale.24.value}'
```

ビルド結果（`build/flippers/scss/_variables.scss`、build は gitignore のためコミット対象外）:

- `$size-width-list-leading: 1.5rem !default;`
- `$size-width-description-list-leading: 3rem !default;`（変更なし）

## 値の確定経緯

当初 2.5rem を検討しましたが、admin（`.flippers-list` HTMLクラス）と flippers-vue-components（`FlippersList.vue`）の実描画で余白感を検証した結果、**1.5rem** に確定しました。

## スコープ外（別対応）

- **縦padding（density）の調整**は `cell` 共有トークン由来で table 等に波及するため、本PR（トークン）では対応しません。admin（`admin-common-sass`）と flippers-vue-components（`FlippersList.vue`）側で list 限定の上書きとして対応します。

ref: https://git.pepabo.com/colorme/elephant/issues/80889